### PR TITLE
Add -Xdoclint:none to maven-javadoc-plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -379,6 +379,7 @@ target platform and specify -Dntdll_target=msbuild on the mvn command line.
           <excludedocfilessubdir>.svn</excludedocfilessubdir>
           <encoding>UTF-8</encoding>
           <docEncoding>UTF-8</docEncoding>
+          <additionalparam>-Xdoclint:none</additionalparam>
         </configuration>
         <executions>
           <execution>


### PR DESCRIPTION
For the current trun, `mvn clean install` fails due to malformed javadoc. A workaround would be to disable the linting of the javadoc.