### PR TITLE
Bump maven-site-plugin to version 3.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -460,7 +460,7 @@ target platform and specify -Dntdll_target=msbuild on the mvn command line.
         </plugin>
       <plugin>
         <artifactId>maven-site-plugin</artifactId>
-        <version>3.1</version>
+        <version>3.3</version>
         <executions>
           <execution>
             <phase>package</phase>


### PR DESCRIPTION
For the current trunk, running `mvn clean install -Xdoclint:none` results in:

`java.lang.NoClassDefFoundError: org/sonatype/aether/graph/DependencyFilter`

A quick search suggests that the version of the plugin [should be bumped][1]. That makes the problem go away.

[1]: https://stackoverflow.com/questions/22018350/sqoop2-build-fails-missing-org-sonatype-aether-graph-dependencyfilter?utm_medium=organic&utm_source=google_rich_qa&utm_campaign=google_rich_qa