### PR TITLE
fix StringIndexOutOfBoundsException

### DIFF
--- a/src/main/java/org/apache/log4j/config/PropertyPrinter.java
+++ b/src/main/java/org/apache/log4j/config/PropertyPrinter.java
@@ -155,7 +155,7 @@ public class PropertyPrinter implements PropertyGetter.PropertyCallback {
   }
   
   public static String capitalize(String name) {
-    if (Character.isLowerCase(name.charAt(0))) {
+    if (!name.isEmpty() && Character.isLowerCase(name.charAt(0))) {
       if (name.length() == 1 || Character.isLowerCase(name.charAt(1))) {
         StringBuffer newname = new StringBuffer(name);
         newname.setCharAt(0, Character.toUpperCase(name.charAt(0)));


### PR DESCRIPTION
`
@Test
    public void test(){
      `String` str = "";
      PropertyPrinter.capitalize(str);
    }
`
**the testcase reports exception information:**

`
java.lang.StringIndexOutOfBoundsException: String index out of range: 0
	at java.lang.String.charAt(String.java:658)
	at org.apache.log4j.config.PropertyPrinter.capitalize(PropertyPrinter.java:151)
`

**reason:**
in function capitalize: before calling String.charAt(int),did not check the length Of String
